### PR TITLE
#100 AppBarの背景色修正

### DIFF
--- a/lib/presentation/view/pages/message/message_page.dart
+++ b/lib/presentation/view/pages/message/message_page.dart
@@ -30,8 +30,9 @@ class MessagePage extends HookConsumerWidget {
               style: TextStyle(fontSize: 20, color: BrandColor.textBlack),
             ),
             elevation: 0,
-            backgroundColor: Colors.transparent,
+            backgroundColor: BrandColor.base,
             iconTheme: const IconThemeData(color: BrandColor.textBlack),
+            scrolledUnderElevation: 0.0,
           ),
           body: usersState.when(
             data: (data) {


### PR DESCRIPTION
## AppBar背景色修正 #100 

### コード修正点・追加点

-MessagePageのAppBarでscrolledUnderElevation: 0.0を設定

### Q&A
スクロールするページがあれば、個別に設定が必要のようです。他のページでスクロールが見当たらなかったため、今回はMessagePageのみ設定しました。
必要であればコンポーネント化するのもありかもです

### スクリーンショット
![Simulator Screenshot - iPhone Xs - 2024-05-07 at 15 30 46](https://github.com/junjun-1345/aizuchi_app/assets/107928941/9f504186-869c-4178-ab37-940b98b6f7fa)

