### PR TITLE
#126 認証連携ページ

### DIFF
--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -1,4 +1,5 @@
 import 'package:aizuchi_app/domain/entity/models/user.dart';
+import 'package:aizuchi_app/infrastructure/enums/auth_provider.dart';
 
 abstract class AuthRepository {
   Future<void> signUpWithEmail(
@@ -18,4 +19,5 @@ abstract class AuthRepository {
   Future<String?> readEmail();
   Future<void> updateEmail(String email);
   Future<void> updatePassword(String email);
+  Future<List<AuthProviderType>> getCurrentUserProvider();
 }

--- a/lib/infrastructure/enums/auth_provider.dart
+++ b/lib/infrastructure/enums/auth_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+enum AuthProviderType {
+  google,
+  facebook,
+  twitter,
+  apple,
+  emailAndPassword,
+  phone,
+  unknown
+}
+
+extension AuthProviderExtension on AuthProviderType {
+  // プロバイダIDとAuthProviderTypeのマッピング
+  static final providerValues = {
+    AuthProviderType.google: "google.com",
+    AuthProviderType.facebook: "facebook.com",
+    AuthProviderType.twitter: "twitter.com",
+    AuthProviderType.apple: "apple.com",
+    AuthProviderType.emailAndPassword: "password",
+    AuthProviderType.phone: "phone",
+    AuthProviderType.unknown: "unknown",
+  };
+
+  // プロバイダIDを取得するゲッター
+  String? get providerId => providerValues[this];
+
+  // 文字列からAuthProviderへの変換
+  static AuthProviderType from(String rawValue) {
+    return AuthProviderType.values.firstWhere(
+      (e) => e.providerId == rawValue,
+      orElse: () => AuthProviderType.unknown,
+    );
+  }
+}
+
+extension AuthProviderTypeExtension on AuthProviderType {
+  IconData get icon {
+    switch (this) {
+      case AuthProviderType.google:
+        return FontAwesomeIcons.google;
+      case AuthProviderType.facebook:
+        return FontAwesomeIcons.facebook;
+      case AuthProviderType.twitter:
+        return FontAwesomeIcons.twitter;
+      case AuthProviderType.apple:
+        return FontAwesomeIcons.apple;
+      case AuthProviderType.emailAndPassword:
+        return Icons.email;
+      case AuthProviderType.phone:
+        return Icons.phone;
+      default:
+        return Icons.help_outline;
+    }
+  }
+}

--- a/lib/infrastructure/repositories/auth_repositories_impl.dart
+++ b/lib/infrastructure/repositories/auth_repositories_impl.dart
@@ -1,5 +1,6 @@
 import 'package:aizuchi_app/domain/entity/models/user.dart';
 import 'package:aizuchi_app/domain/repositories/auth_repository.dart';
+import 'package:aizuchi_app/infrastructure/enums/auth_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
@@ -286,6 +287,20 @@ class AuthRepositoryImpl implements AuthRepository {
       }
     } on Exception {
       throw 'エラーが発生しました。もう一度お試しください。';
+    }
+  }
+
+  @override
+  Future<List<AuthProviderType>> getCurrentUserProvider() async {
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user != null) {
+      final List<UserInfo> providerData = user.providerData;
+      return providerData.map((userInfo) {
+        return AuthProviderExtension.from((userInfo.providerId));
+      }).toList();
+    } else {
+      return [];
     }
   }
 }

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -8,6 +8,7 @@ import 'package:aizuchi_app/presentation/view/pages/profile/current_profile_page
 import 'package:aizuchi_app/presentation/view/pages/profile/edit_profile_page%20.dart';
 import 'package:aizuchi_app/presentation/view/pages/root_page.dart';
 import 'package:aizuchi_app/presentation/view/pages/search/search.dart';
+import 'package:aizuchi_app/presentation/view/pages/settings/auth/authentication_cooperation_page.dart';
 import 'package:aizuchi_app/presentation/view/pages/settings/mail/mail_confirm_page.dart';
 import 'package:aizuchi_app/presentation/view/pages/settings/notification/notification_page.dart';
 import 'package:aizuchi_app/presentation/view/pages/settings/password/password_change_page.dart';
@@ -103,6 +104,10 @@ class AppRouter extends _$AppRouter implements AutoRouteGuard {
           page: PurchaseRoute.page,
         ),
         AutoRoute(
+          path: '/AuthenticationCooperation',
+          page: AuthenticationCooperationRoute.page,
+        ),
+        AutoRoute(
           path: '/MailConfirm',
           page: MailConfrimRoute.page,
         ),
@@ -125,7 +130,7 @@ class AppRouter extends _$AppRouter implements AutoRouteGuard {
         AutoRoute(
           path: '/EditProfilePage',
           page: EditProfileRoute.page,
-          ),
+        ),
         AutoRoute(
           path: '/NotificationPage',
           page: NotificationRoute.page,

--- a/lib/presentation/router/router.dart
+++ b/lib/presentation/router/router.dart
@@ -116,6 +116,7 @@ class AppRouter extends _$AppRouter {
         AutoRoute(
           path: '/AuthenticationCooperation',
           page: AuthenticationCooperationRoute.page,
+          guards: [AuthGuard()],
         ),
         AutoRoute(
           path: '/MailConfirm',

--- a/lib/presentation/router/router.gr.dart
+++ b/lib/presentation/router/router.gr.dart
@@ -15,6 +15,12 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
+    AuthenticationCooperationRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AuthenticationCooperationPage(),
+      );
+    },
     CalenderRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -156,6 +162,20 @@ abstract class _$AppRouter extends RootStackRouter {
       );
     },
   };
+}
+
+/// generated route for
+/// [AuthenticationCooperationPage]
+class AuthenticationCooperationRoute extends PageRouteInfo<void> {
+  const AuthenticationCooperationRoute({List<PageRouteInfo>? children})
+      : super(
+          AuthenticationCooperationRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AuthenticationCooperationRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for

--- a/lib/presentation/view/components/drawer_content.dart
+++ b/lib/presentation/view/components/drawer_content.dart
@@ -80,7 +80,11 @@ class HamburgerMenu extends ConsumerWidget {
         _buildSectionItem(
           title: "認証連携",
           icon: Icons.manage_accounts_sharp,
-          onTap: () {},
+          onTap: () {
+            context.router.push(
+              const AuthenticationCooperationRoute(),
+            );
+          },
           verticalType: VerticalType.top,
         ),
         _buildSectionItem(

--- a/lib/presentation/view/pages/settings/auth/authentication_cooperation_page.dart
+++ b/lib/presentation/view/pages/settings/auth/authentication_cooperation_page.dart
@@ -1,0 +1,66 @@
+import 'package:aizuchi_app/domain/entity/models/color.dart';
+import 'package:aizuchi_app/infrastructure/data_model.dart';
+import 'package:aizuchi_app/infrastructure/enums/auth_provider.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+@RoutePage()
+class AuthenticationCooperationPage extends HookConsumerWidget {
+  const AuthenticationCooperationPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authRepository = ref.read(authRepositoryProvider);
+    final getCurrentUserProviders = authRepository.getCurrentUserProvider();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("認証連携", style: TextStyle(color: BrandColor.black)),
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        iconTheme: const IconThemeData(color: BrandColor.textBlack),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Center(
+          child: FutureBuilder(
+            future: getCurrentUserProviders,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const CircularProgressIndicator();
+              }
+              if (snapshot.hasError) {
+                return const Text("エラーが発生しました");
+              }
+              return Column(
+                children: [
+                  const SizedBox(height: 48),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: BrandColor.white,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    height: 48,
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 0, horizontal: 16.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          "認証プラットフォーム",
+                          style: const TextStyle(fontWeight: FontWeight.w500),
+                        ),
+                        Icon(snapshot.data!.first.icon,
+                            color: BrandColor.textBlack),
+                      ],
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
##  認証連携ページ #126

### コード修正点・追加点
-  認証連携ページ作成
-  認証連携取得機能作成
- プラットフォームのenum作成

### Q&A

### スクリーンショット
<img src=https://github.com/junjun-1345/aizuchi_app/assets/76525601/e1d192c8-043f-4534-8295-b427b3d651f2  width=50%>

