### PR TITLE
チャットページUI変更

### DIFF
--- a/lib/presentation/view/components/app_textform.dart
+++ b/lib/presentation/view/components/app_textform.dart
@@ -225,6 +225,7 @@ class AppTextForm {
       decoration: InputDecoration(
         fillColor: Colors.grey[200],
         hintText: "メッセージを入力",
+        hintStyle: const TextStyle(fontSize: 14),
         filled: true,
         //これがないと余白をとりすぎる
         isDense: true,

--- a/lib/presentation/view/pages/message/components/message_footer_contents.dart
+++ b/lib/presentation/view/pages/message/components/message_footer_contents.dart
@@ -50,7 +50,7 @@ class MessageFooterContents extends ConsumerWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               AppButton.small(
-                width: 80,
+                width: 100,
                 height: 40,
                 onPressed: () {
                   if (isWaiting) {
@@ -62,7 +62,7 @@ class MessageFooterContents extends ConsumerWidget {
                     ref.read(messageViewModelProvider).createSummary();
                   }
                 },
-                text: "終了",
+                text: "おわる",
               ),
               const SizedBox(width: 8),
 
@@ -138,7 +138,7 @@ class MessageFooterContents extends ConsumerWidget {
                       elevation: 0,
                       shape: const StadiumBorder(),
                       backgroundColor: BrandColor.baseRed),
-                  text: ("日記を書く"),
+                  text: ("お話しする"),
                 ),
         ],
       );


### PR DESCRIPTION
## チャットページUI変更 #142 

### コード修正点・追加点

-　 終了を終わるに変更
- 　テキストフィールド、ヒントテキスト、フォントサイズ本文と同じに
- 　日記を書く→会話をする

### Q&A

### スクリーンショット
![Simulator Screenshot - iPhone 15 Plus - 2024-05-26 at 21 39 42](https://github.com/junjun-1345/aizuchi_app/assets/107928941/32b9a22f-a9dd-43dd-9101-4bc975a06a1b)
![Simulator Screenshot - iPhone 15 Plus - 2024-05-26 at 21 37 16](https://github.com/junjun-1345/aizuchi_app/assets/107928941/aa535bf5-7403-4f7a-b826-ebbe683504fc)
